### PR TITLE
fix prost-derive

### DIFF
--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -15,7 +15,7 @@ proc_macro = true
 
 [dependencies]
 failure = { version = "0.1", default-features = false, features = ["std"] }
-itertools = "0.8"
+itertools = { version = "0.8", default-features = false }
 proc-macro2 = "0.4.4"
 quote = "0.6.3"
 syn = { version = "0.15", features = [ "extra-traits" ] }


### PR DESCRIPTION
Fix the conflict between prost-derive and  fns, which is caused by itertools.
